### PR TITLE
pin gradio to avoid unexpected kwarg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 openai>=1.52.0
 python-dotenv>=1.0.1
 dspy
-gradio>=5.49.1
+gradio>=5.49.1,<6.0
 bids_validator


### PR DESCRIPTION
When I ran locally after `pip install requirements.txt` I hit the following error:

```
 venv  ~/devel/OpenBIDSifier   main ± python gradio-ui.py 
Traceback (most recent call last):
  File "/home/austin/devel/OpenBIDSifier/gradio-ui.py", line 532, in <module>
    with gr.Blocks(
         ~~~~~~~~~^
        title="BIDSifier Agent Interface",
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
        """,
        ^^^^
    ) as demo:
    ^
  File "/home/austin/devel/OpenBIDSifier/venv/lib64/python3.13/site-packages/gradio/blocks.py", line 1071, in __init__
    super().__init__(render=False, **kwargs)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: BlockContext.__init__() got an unexpected keyword argument 'theme'
```

I had `gradio-6.0.1`, dropping to `gradio 5.50.0` fixed and I was able to run.

If you prefer to update to use 6.0+ I'd be happy to give that a shot (not familiar with gradio yet, but could be trivial).
